### PR TITLE
use source.ts includes to ensure highlighting works on github

### DIFF
--- a/syntaxes/edge.tmLanguage.json
+++ b/syntaxes/edge.tmLanguage.json
@@ -3,7 +3,7 @@
 	"name": "Edge",
 	"scopeName": "text.html.edge",
   "injections": {
-    "text.html.edge - (meta.embedded | meta.tag | comment.block.edge), L:(text.html.edge meta.tag - (comment.block.edge | meta.embedded.block.edge)), L:(source.js.embedded.html - (comment.block.edge | meta.embedded.block.edge))": {
+    "text.html.edge - (meta.embedded | meta.tag | comment.block.edge), L:(text.html.edge meta.tag - (comment.block.edge | meta.embedded.block.edge)), L:(source.ts.embedded.html - (comment.block.edge | meta.embedded.block.edge))": {
       "patterns": [
         {
           "include": "#comment"
@@ -59,7 +59,7 @@
         "0": { "name": "punctuation.mustache.end" }
       },
       "name": "meta.embedded.block.javascript",
-      "patterns": [{ "include": "source.js#expression" }]
+      "patterns": [{ "include": "source.ts#expression" }]
 		},
     "mustache": {
       "begin": "\\{{",
@@ -71,7 +71,7 @@
         "0": { "name": "punctuation.mustache.end" }
       },
       "name": "meta.embedded.block.javascript",
-      "patterns": [{ "include": "source.js#expression" }]
+      "patterns": [{ "include": "source.ts#expression" }]
 		},
     "nonSeekableTag": {
       "match": "^(\\s*)((@{1,2})(!)?([a-zA-Z._]+))(~)?$",
@@ -79,7 +79,7 @@
         "2": { "name": "support.function.edge" }
       },
       "name": "meta.embedded.block.javascript",
-      "patterns": [{ "include": "source.js#expression" }]
+      "patterns": [{ "include": "source.ts#expression" }]
     },
     "tag": {
       "begin": "^(\\s*)((@{1,2})(!)?([a-zA-Z._]+)(\\s{0,2}))(\\()",
@@ -92,7 +92,7 @@
         "0": { "name": "punctuation.paren.close" }
       },
       "name": "meta.embedded.block.javascript",
-      "patterns": [{ "include": "source.js#expression" }]
+      "patterns": [{ "include": "source.ts#expression" }]
     }
 	},
 	"patterns": [


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#2

https://discord.com/channels/423256550564691970/1200066074297782323

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've had confirmation that github uses the atom javascript grammar rather than the microsoft javascript grammar when being included in a textmate grammar. This means `source.js#expression` will not work on github.

You can see how github will highlight edge files using this preview app which also used the atom javascript grammar.
[Nova Lightshow JS preview](https://novalightshow.netlify.app/?grammar-type=url&grammar=https%3A%2F%2Fraw.githubusercontent.com%2Fedge-js%2Fedge-vscode%2Fmain%2Fsyntaxes%2Fedge.tmLanguage.json&sample-type=url&sample=https%3A%2F%2Fraw.githubusercontent.com%2Fedge-js%2Fedge%2Fdevelop%2Fexamples%2Fviews%2Fwelcome.edge)
<img width="777" alt="image" src="https://github.com/edge-js/edge-vscode/assets/83799/bdfce8ac-d65c-42b4-a328-3cf93e42f1fc">


This is how it highlights using source.ts instead
[Nova Lightshow TS preview](https://novalightshow.netlify.app/?grammar-type=url&grammar=https%3A%2F%2Fraw.githubusercontent.com%2Fevoactivity%2Fedge-vscode%2Fuse-typescript-grammar-include%2Fsyntaxes%2Fedge.tmLanguage.json&sample-type=url&sample=https%3A%2F%2Fraw.githubusercontent.com%2Fedge-js%2Fedge%2Fdevelop%2Fexamples%2Fviews%2Fwelcome.edge)
<img width="753" alt="image" src="https://github.com/edge-js/edge-vscode/assets/83799/5fa0d1ca-b0ea-48d6-9085-b0f94aacf792">


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] ~~I have updated the documentation accordingly.~~ (no need)
