### PR TITLE
fix(vscode): correct @let completion snippet syntax

### DIFF
--- a/src/vscode/builtin_tags_completion.ts
+++ b/src/vscode/builtin_tags_completion.ts
@@ -152,7 +152,7 @@ debuggerItem.detail = 'Define debugger breakpoint'
  * `@let`
  */
 const letItem = new CompletionItem('let', CompletionItemKind.Keyword)
-letItem.insertText = new SnippetString('let ${1:variable} = ${2:value}')
+letItem.insertText = new SnippetString("let(${1:variable} = '${2:value}')")
 letItem.documentation = new MarkdownString(
   'Define a local variable\n\nhttps://edgejs.dev/docs/templates_state#inline-variables'
 )


### PR DESCRIPTION
Update 'let' completion to insert let(${1:variable} = '${2:value}') to
match Edge template syntax and docs, avoiding invalid snippets. Also
switch to double-quoted TS string to allow single quotes in the snippet.